### PR TITLE
Revamp portfolio theme

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -2,10 +2,10 @@
   <ion-toolbar>
     <ion-title>JNVR</ion-title>
     <ion-buttons slot="end">
-      <ion-button routerLink="/home">Home</ion-button>
-      <ion-button routerLink="/about">About</ion-button>
-      <ion-button routerLink="/projects">Projects</ion-button>
-      <ion-button routerLink="/contact">Contact</ion-button>
+      <ion-button fill="clear" routerLink="/home">Home</ion-button>
+      <ion-button fill="clear" routerLink="/about">About</ion-button>
+      <ion-button fill="clear" routerLink="/projects">Projects</ion-button>
+      <ion-button fill="clear" routerLink="/contact">Contact</ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,4 +1,5 @@
 ion-toolbar {
-  --background: #3880ff;
+  --background: var(--ion-color-primary);
   color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }

--- a/src/app/pages/contact/contact.page.scss
+++ b/src/app/pages/contact/contact.page.scss
@@ -8,7 +8,7 @@
 
 /* Estilos para el ion-card modificado */
 .custom-card {
-  background: #133849f3;; /* Fondo blanco con ligera transparencia para resaltar sobre el gradiente */
+  background: var(--card-bg);
   border-radius: 16px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   width: 90%;
@@ -66,5 +66,5 @@ ion-label a:hover {
   text-decoration: underline;
 }
 ion-list{
-  background-color: #133849f3;
+  background-color: var(--card-bg);
 }

--- a/src/app/pages/experience/experience.page.scss
+++ b/src/app/pages/experience/experience.page.scss
@@ -12,7 +12,7 @@
   top: 0;
   bottom: 0;
   width: 2px;
-  background: #ccc;
+  background: var(--ion-color-secondary);
 }
 
 .timeline-item {
@@ -27,12 +27,12 @@
   top: 0;
   width: 20px;
   height: 20px;
-  background: #007bff;
+  background: var(--ion-color-primary);
   border-radius: 50%;
 }
 
 .timeline-content {
-  background: #133849f3;
+  background: var(--card-bg);
   padding: 1rem 1.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -42,24 +42,24 @@
 }
 
 .timeline-content:hover {
-  background: linear-gradient(135deg, #2f87b085 30%, #1c5c8a70 100%);
+  background: var(--ion-color-primary);
 }
 
 .timeline-content h2 {
   margin: 0;
   font-size: 1.5rem;
-  color: #e9e9e9;
+  color: var(--ion-text-color);
 }
 
 .timeline-content h3 {
   margin: 0.5rem 0;
   font-size: 1.2rem;
-  color: #d3d3d3;
+  color: var(--ion-text-color);
 }
 
 .timeline-info {
   font-size: 0.9rem;
-  color: #e7e7e7;
+  color: var(--ion-text-color);
   margin-bottom: 0.5rem;
 }
 
@@ -87,7 +87,7 @@
   margin-top: 1rem;
 }
 .chip{
-  background: #007bff;
+  background: var(--ion-color-primary);
   color: white;
   padding: 0.5rem 1rem;
   border-radius: 1rem;

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -1,16 +1,17 @@
-:root {
-  // Ajusta estos valores con el color de tu logo
-  --ion-background-color: linear-gradient(135deg, #2f87b085 30%, #1c5c8a70 100%);
-  --ion-background-color2: linear-gradient(135deg, #2f87b085 30%, #1c5c8a70 100%);
-  --ion-color-primary: #2F88B0;
-  --ion-color-primary-rgb: 47, 136, 176;
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap');
 
-  /* Opcional: define colores secundarios o de texto */
-  --ion-color-secondary: #2F88B0;
-  --ion-text-color: #e0dede;
+:root {
+  --ion-background-color: linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%);
+  --ion-background-color2: linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%);
+  --ion-color-primary: #e63946;
+  --ion-color-primary-rgb: 230, 57, 70;
+
+  --ion-color-secondary: #457b9d;
+  --ion-text-color: #f1faee;
+  --card-bg: rgba(27, 38, 59, 0.85);
 }
 body {
-  font-family: 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Poppins', sans-serif;
   --ion-background-color: var(--ion-background-color2);
   color: var(--ion-text-color);
 }


### PR DESCRIPTION
## Summary
- modernize theme colors and fonts
- refine header styling and navigation buttons
- adjust contact card and experience timeline styles to use new palette

## Testing
- `npm run lint`
- `npm test` *(fails: ChromeHeadless missing)*

------
https://chatgpt.com/codex/tasks/task_e_68894d8860dc83289ca2edb70c8192a0