### PR TITLE
Redesign portfolio to dark theme

### DIFF
--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,14 +1,21 @@
 ion-toolbar {
-  --background: #fff;
-  color: var(--ion-color-primary);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --background: var(--header-background);
+  color: var(--ion-text-color);
+  box-shadow: none;
 }
 
 ion-title {
   font-weight: 600;
+  font-family: 'Fira Code', monospace;
+  color: var(--ion-color-primary);
 }
 
 ion-button {
-  color: var(--ion-color-primary);
+  color: var(--ion-text-color);
   font-weight: 500;
+  font-family: 'Fira Code', monospace;
+}
+
+ion-button:hover {
+  color: var(--ion-color-primary);
 }

--- a/src/app/pages/contact/contact.page.scss
+++ b/src/app/pages/contact/contact.page.scss
@@ -57,7 +57,7 @@ ion-item {
 }
 
 ion-label a {
-  color: var(--ion-color-text);
+  color: var(--ion-text-color);
   text-decoration: none;
   font-weight: 500;
 }

--- a/src/app/pages/experience/experience.page.scss
+++ b/src/app/pages/experience/experience.page.scss
@@ -48,18 +48,18 @@
 .timeline-content h2 {
   margin: 0;
   font-size: 1.5rem;
-  color: #e9e9e9;
+  color: var(--ion-text-color);
 }
 
 .timeline-content h3 {
   margin: 0.5rem 0;
   font-size: 1.2rem;
-  color: #d3d3d3;
+  color: var(--ion-text-color);
 }
 
 .timeline-info {
   font-size: 0.9rem;
-  color: #e7e7e7;
+  color: var(--ion-text-color);
   margin-bottom: 0.5rem;
 }
 
@@ -87,7 +87,7 @@
   margin-top: 1rem;
 }
 .chip{
-  background: #007bff;
+  background: var(--ion-color-primary);
   color: white;
   padding: 0.5rem 1rem;
   border-radius: 1rem;

--- a/src/app/pages/projects/projects.page.scss
+++ b/src/app/pages/projects/projects.page.scss
@@ -36,7 +36,7 @@
   left: 0;
   right: 0;
   background: rgba(0, 0, 0, 0.7);
-  color: #fff;
+  color: var(--ion-text-color);
   padding: 1rem;
   opacity: 0;
   transition: opacity 0.3s ease;

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="assets/logo/logo-jnvr.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Fira+Code:wght@400;600&display=swap" rel="stylesheet" />
 
   <!-- add to homescreen for ios -->
   <meta name="mobile-web-app-capable" content="yes" />

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -1,20 +1,21 @@
 :root {
   /* Colores base */
-  --ion-background-color: #f2f4f8;
-  --ion-color-primary: #0066cc;
-  --ion-color-primary-rgb: 0, 102, 204;
-  --ion-color-secondary: #0066cc;
-  --ion-text-color: #333;
+  --ion-background-color: #0a192f;
+  --ion-color-primary: #64ffda;
+  --ion-color-primary-rgb: 100, 255, 218;
+  --ion-color-secondary: #64ffda;
+  --ion-text-color: #ccd6f6;
+  --header-background: #0a192f;
 }
 body {
-  font-family: 'Poppins', Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
   background: var(--ion-background-color);
   color: var(--ion-text-color);
 }
 
 ion-toolbar {
-  --background: #fff;
-  color: var(--ion-color-primary);
+  --background: var(--header-background);
+  color: var(--ion-text-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -40,6 +41,8 @@ ion-toolbar {
 /* Efecto de hover para las tarjetas */
 ion-card {
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+  background: #112240;
+  color: var(--ion-text-color);
 }
 ion-card:hover {
   transform: translateY(-5px);


### PR DESCRIPTION
## Summary
- switch to Inter and Fira Code fonts
- implement dark theme colors and adjust header styling
- unify card text colors and contact link style

## Testing
- `npm test` *(fails: ChromeHeadless missing)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688954eb6bf0832895878caf5195e6a3