### PR TITLE
Update theme with dark redesign

### DIFF
--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,7 +1,7 @@
 ion-toolbar {
-  --background: #fff;
+  --background: #0a192f;
   color: var(--ion-color-primary);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 ion-title {
@@ -9,6 +9,11 @@ ion-title {
 }
 
 ion-button {
-  color: var(--ion-color-primary);
+  color: var(--ion-text-color);
   font-weight: 500;
+  --background: transparent;
+}
+
+ion-button:hover {
+  color: var(--ion-color-primary);
 }

--- a/src/app/pages/contact/contact.page.scss
+++ b/src/app/pages/contact/contact.page.scss
@@ -8,7 +8,7 @@
 
 /* Estilos para el ion-card modificado */
 .custom-card {
-  background: #133849f3;; /* Fondo blanco con ligera transparencia para resaltar sobre el gradiente */
+  background: #112240f2; /* Fondo oscuro con ligera transparencia */
   border-radius: 16px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   width: 90%;
@@ -66,5 +66,5 @@ ion-label a:hover {
   text-decoration: underline;
 }
 ion-list{
-  background-color: #133849f3;
+  background-color: #112240f2;
 }

--- a/src/app/pages/experience/experience.page.scss
+++ b/src/app/pages/experience/experience.page.scss
@@ -32,7 +32,7 @@
 }
 
 .timeline-content {
-  background: #133849f3;
+  background: #112240f2;
   padding: 1rem 1.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -29,11 +29,12 @@
     order: 1; /* Ensure the text is on the left */
 
     .hero-text {
-      font-size: 1.2rem;
+      font-size: 2rem;
       line-height: 1.4;
-      text-align: justify;
-      min-height: 5rem; /* Para mantener una altura estable */
+      text-align: center;
+      min-height: 6rem; /* Para mantener una altura estable */
       color: var(--ion-text-color);
+      font-weight: 600;
     }
   }
 
@@ -58,12 +59,18 @@
   opacity: 0;
   transform: translateX(0.5rem);
   transition: transform 0.6s cubic-bezier(0.68, -0.55, 0.27, 1.55), opacity 0.6s ease-in-out;
+  background: linear-gradient(90deg, var(--ion-color-primary), #8892b0);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 /* Cuando la palabra se vuelve visible */
 .word.visible {
   transform: translateX(0);
   opacity: 1;
+  background: linear-gradient(90deg, var(--ion-color-primary), #8892b0);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 /* Animación para la tarjeta (fadeInUp) */

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="assets/logo/logo-jnvr.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
 
   <!-- add to homescreen for ios -->
   <meta name="mobile-web-app-capable" content="yes" />

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -1,21 +1,21 @@
 :root {
   /* Colores base */
-  --ion-background-color: #f2f4f8;
-  --ion-color-primary: #0066cc;
-  --ion-color-primary-rgb: 0, 102, 204;
-  --ion-color-secondary: #0066cc;
-  --ion-text-color: #333;
+  --ion-background-color: #0a192f;
+  --ion-color-primary: #64ffda;
+  --ion-color-primary-rgb: 100, 255, 218;
+  --ion-color-secondary: #64ffda;
+  --ion-text-color: #ccd6f6;
 }
 body {
-  font-family: 'Poppins', Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
   background: var(--ion-background-color);
   color: var(--ion-text-color);
 }
 
 ion-toolbar {
-  --background: #fff;
+  --background: #0a192f;
   color: var(--ion-color-primary);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 


### PR DESCRIPTION
## Summary
- switch to a dark color palette and Inter font
- restyle header buttons
- enlarge hero text with gradient color
- adjust contact and experience cards to match dark theme

## Testing
- `npm run lint`
- `npm test --silent` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_688954eb6bf0832895878caf5195e6a3