### PR TITLE
Highlight active route on header

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -2,10 +2,10 @@
   <ion-toolbar>
     <ion-title>JNVR</ion-title>
     <ion-buttons slot="end">
-      <ion-button routerLink="/home">Home</ion-button>
-      <ion-button routerLink="/about">About</ion-button>
-      <ion-button routerLink="/projects">Projects</ion-button>
-      <ion-button routerLink="/contact">Contact</ion-button>
+      <ion-button routerLink="/home" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Home</ion-button>
+      <ion-button routerLink="/about" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">About</ion-button>
+      <ion-button routerLink="/projects" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Projects</ion-button>
+      <ion-button routerLink="/contact" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Contact</ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -12,3 +12,8 @@ ion-button {
   color: var(--ion-color-primary);
   font-weight: 500;
 }
+
+ion-button.active {
+  background: var(--ion-color-primary);
+  color: #fff;
+}

--- a/src/app/components/header/header.component.spec.ts
+++ b/src/app/components/header/header.component.spec.ts
@@ -1,7 +1,27 @@
-import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router, RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { HeaderComponent } from './header.component';
 
+@Component({template: ''})
+class DummyComponent {}
+
 describe('HeaderComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HeaderComponent,
+        RouterTestingModule.withRoutes([
+          { path: 'home', component: DummyComponent },
+          { path: 'about', component: DummyComponent },
+          { path: 'projects', component: DummyComponent },
+          { path: 'contact', component: DummyComponent },
+        ])
+      ]
+    }).compileComponents();
+  });
+
   it('should create', () => {
     const fixture = TestBed.createComponent(HeaderComponent);
     const component = fixture.componentInstance;
@@ -15,4 +35,16 @@ describe('HeaderComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelectorAll('ion-button').length).toBeGreaterThan(0);
   });
+
+  it('should apply active class to current route button', fakeAsync(() => {
+    const fixture = TestBed.createComponent(HeaderComponent);
+    const router = TestBed.inject(Router);
+    router.navigateByUrl('/about');
+    tick();
+    fixture.detectChanges();
+
+    const buttons = fixture.nativeElement.querySelectorAll('ion-button');
+    const aboutButton = buttons[1];
+    expect(aboutButton.classList.contains('active')).toBeTrue();
+  }));
 });


### PR DESCRIPTION
## Summary
- visually highlight active header links using `routerLinkActive`
- style active buttons
- test active class behavior using RouterTestingModule

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6889a3561ff08328b50dd2372494a3d6