### PR TITLE
Fix timeout cleanup on home and about pages

### DIFF
--- a/src/app/pages/about/about.page.spec.ts
+++ b/src/app/pages/about/about.page.spec.ts
@@ -19,4 +19,11 @@ describe('AboutPage', () => {
     component.ngOnInit();
     expect(component.wordsEls.length).toBe(component.fullText.split(' ').length);
   });
+
+  it('should clear timeouts on destroy', () => {
+    component.ngOnInit();
+    expect((component as any).timeouts.length).toBeGreaterThan(0);
+    component.ngOnDestroy();
+    expect((component as any).timeouts.length).toBe(0);
+  });
 });

--- a/src/app/pages/about/about.page.ts
+++ b/src/app/pages/about/about.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonCard, IonCardHeader, IonCardTitle, IonCardContent, IonImg, IonCardSubtitle, IonHeader, IonToolbar } from '@ionic/angular/standalone';
@@ -10,7 +10,7 @@ import { IonCard, IonCardHeader, IonCardTitle, IonCardContent, IonImg, IonCardSu
   standalone: true,
   imports: [IonImg, IonCardContent, IonCard, CommonModule, FormsModule]
 })
-export class AboutPage implements OnInit {
+export class AboutPage implements OnInit, OnDestroy {
 
   // Texto completo a mostrar
   fullText: string = "My name is Jonathan Noe Viramontes Ramirez, a software engineer passionate about technology and innovation. I love to create interactive applications and lead projects that make a positive impact.";
@@ -20,6 +20,7 @@ export class AboutPage implements OnInit {
 
   // Variable que se inyecta en el template mediante [innerHTML]
   displayedText: string = '';
+  private timeouts: any[] = [];
 
   ngOnInit() {
     // Separamos el texto en palabras y las envolvemos en un span con clase "word"
@@ -32,16 +33,23 @@ export class AboutPage implements OnInit {
         this.wordsEls[index] = this.wordsEls[index].replace('class="word"', 'class="word visible"');
         // Actualizamos el contenido a mostrar
         this.displayedText = this.wordsEls.join('');
-        setTimeout(() => {
+        const id = setTimeout(() => {
           updateArrayWithDelay(index + 1);
         }, 100); // Ajusta este valor (30ms) según la velocidad deseada
+        this.timeouts.push(id);
       }
     };
 
     // Iniciamos la animación con un pequeño retraso
-    setTimeout(() => {
+    const startId = setTimeout(() => {
       updateArrayWithDelay();
     }, 60);
+    this.timeouts.push(startId);
+  }
+
+  ngOnDestroy() {
+    this.timeouts.forEach(clearTimeout);
+    this.timeouts = [];
   }
 
 }

--- a/src/app/pages/home/home.page.spec.ts
+++ b/src/app/pages/home/home.page.spec.ts
@@ -21,4 +21,12 @@ describe('HomePage', () => {
     expect(component.words.length).toBeGreaterThan(0);
     expect(component.words).toEqual(component.fullText.split(' '));
   });
+
+  it('should clear timeouts on destroy', () => {
+    component.ngOnInit();
+    component.ionViewDidEnter();
+    expect((component as any).timeouts.length).toBeGreaterThan(0);
+    component.ngOnDestroy();
+    expect((component as any).timeouts.length).toBe(0);
+  });
 });

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';  // Importa CommonModule
 import { IonContent, IonCardContent, IonImg, IonCard } from '@ionic/angular/standalone';
 import { ExperiencePage } from "../experience/experience.page";
@@ -12,7 +12,7 @@ import { ProjectsPage } from '../projects/projects.page';
   // Se agrega CommonModule para habilitar *ngFor y [ngClass]
   imports: [CommonModule, IonContent, ExperiencePage, ContactPage, ProjectsPage, IonCardContent, IonImg, IonCard],
 })
-export class HomePage implements OnInit {
+export class HomePage implements OnInit, OnDestroy {
   // Texto completo a mostrar
   fullText: string = "Soy Jonathan Noe Viramontes Ramirez, Ingeniero de Software apasionado por la innovación. Me especializo en desarrollar microservicios con FastAPI, crear dashboards interactivos en Power BI y enseñar Python de forma remota. He colaborado con empresas como Fletes México, Museo La Rodadora, IA-Center y Bloomotion, transformando ideas en soluciones tecnológicas efectivas.";
 
@@ -20,6 +20,7 @@ export class HomePage implements OnInit {
   words: string[] = [];
   // Contador de palabras que se han hecho visibles
   visibleWordsCount: number = 0;
+  private timeouts: any[] = [];
 
   ngOnInit() {
     // Separamos el texto en palabras
@@ -33,10 +34,16 @@ export class HomePage implements OnInit {
 
   animateWords(index: number) {
     if (index < this.words.length) {
-      setTimeout(() => {
+      const id = setTimeout(() => {
         this.visibleWordsCount = index + 1;
         this.animateWords(index + 1);
       }, 100); // Ajusta este valor para modificar la velocidad de aparición de cada palabra
+      this.timeouts.push(id);
     }
+  }
+
+  ngOnDestroy() {
+    this.timeouts.forEach(clearTimeout);
+    this.timeouts = [];
   }
 }


### PR DESCRIPTION
## Summary
- implement `OnDestroy` in HomePage and AboutPage
- clear timeout references in `ngOnDestroy`
- add specs verifying timeout cleanup

## Testing
- `npm test` *(fails: ChromeHeadless missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889a3583ed483288f9960f77f822f08